### PR TITLE
Replace f-string with format()

### DIFF
--- a/pyAudioAnalysis/audioBasicIO.py
+++ b/pyAudioAnalysis/audioBasicIO.py
@@ -97,7 +97,10 @@ def read_audio_file(path):
     elif extension in [".mp3", ".wav", ".au", ".ogg"]:
         sampling_rate, signal = read_audio_generic(path)
     else:
-        print(f"Error: unknown file type {extension}")
+        print(
+            "Error: unknown file type {extension}".format(
+                extension=extension
+            ))
 
     if signal.ndim == 2 and signal.shape[1] == 1:
         signal = signal.flatten()


### PR DESCRIPTION
Make the library compatible with Python 3.5 by removing 3.6+ features like f-strings.